### PR TITLE
(maint) Remove lucid from build targets

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,7 +2,7 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-squeeze-i386.cow'
-cows: 'base-jessie-i386.cow base-lucid-i386.cow base-precise-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-trusty-i386.cow base-utopic-i386.cow base-wheezy-i386.cow '
+cows: 'base-jessie-i386.cow base-precise-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-trusty-i386.cow base-utopic-i386.cow base-wheezy-i386.cow '
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppet'
 gpg_name: 'info@puppetlabs.com'


### PR DESCRIPTION
Ubuntu 10.04 (Lucid Lynx) goes EoL 2015-04-30, and as such, we no longer
want to be building packages for this platform.

https://lists.ubuntu.com/archives/ubuntu-announce/2015-March/000193.html