### PR TITLE
(maint) update jruby

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -2,14 +2,14 @@
 packaging_url: 'git://github.com/puppetlabs/packaging.git --branch=master'
 packaging_repo: 'packaging'
 default_cow: 'base-squeeze-i386.cow'
-cows: 'base-jessie-i386.cow base-precise-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-trusty-i386.cow base-utopic-i386.cow base-wheezy-i386.cow '
+cows: 'base-precise-i386.cow base-squeeze-i386.cow base-stable-i386.cow base-testing-i386.cow base-trusty-i386.cow base-wheezy-i386.cow'
 pbuild_conf: '/etc/pbuilderrc'
 packager: 'puppet'
 gpg_name: 'info@puppetlabs.com'
 gpg_key: '4BD6EC30'
 sign_tar: FALSE
 # a space separated list of mock configs
-final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386 pl-fedora-21-i386 pl-fedora-22-i386'
+final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386 pl-fedora-21-i386'
 yum_host: 'yum.puppetlabs.com'
 yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE

--- a/ext/debian/rules
+++ b/ext/debian/rules
@@ -8,7 +8,7 @@ VERSION = 3.1.1
 
 override_dh_auto_install:
 	mkdir -p $(BUILD_ROOT)/opt
-	unzip -qd $(BUILD_ROOT)/opt torquebox-dist-$(VERSION)-bin.zip
+	unzip -qd $(BUILD_ROOT)/opt torquebox-dist-$(VERSION)-1-bin.zip
 	mv $(BUILD_ROOT)/opt/torquebox-$(VERSION) $(BUILD_ROOT)/opt/razor-torquebox
 
 	mkdir -p $(BUILD_ROOT)/etc/razor

--- a/ext/project_data.yaml
+++ b/ext/project_data.yaml
@@ -18,5 +18,5 @@ description: |
   no modifications from the stock TorqueBox, and is used under their license.
 # files and gem_files are space separated lists (or arrays)
 files:
-  - torquebox-dist-3.1.1-bin.zip
+  - torquebox-dist-3.1.1-1-bin.zip
   - razor-torquebox.sh

--- a/ext/redhat/razor-torquebox.spec.erb
+++ b/ext/redhat/razor-torquebox.spec.erb
@@ -43,7 +43,7 @@ rm -rf %{buildroot}
 
 # Install the binary distribution.
 mkdir -p %{buildroot}/opt
-unzip -q -d %{buildroot}/opt torquebox-dist-3.1.1-bin.zip
+unzip -q -d %{buildroot}/opt torquebox-dist-3.1.1-1-bin.zip
 mv %{buildroot}/opt/torquebox-3.1.1 %{buildroot}/opt/razor-torquebox
 
 # Install a nicer, more generic way for consumers of this to interact with it,


### PR DESCRIPTION
Currently, the version of rubygems available through jruby in torquebox
is vulnerable to CVE-2015-4020. This commit updates the version of
rubygems included in jruby to 2.4.6 to mitigate the vulnerability.