### PR TITLE
(maint) remove apt and yum paths from build_defaults

### DIFF
--- a/ext/build_defaults.yaml
+++ b/ext/build_defaults.yaml
@@ -11,12 +11,10 @@ sign_tar: FALSE
 # a space separated list of mock configs
 final_mocks: 'pl-el-5-i386 pl-el-6-i386 pl-el-7-x86_64 pl-fedora-20-i386 pl-fedora-21-i386'
 yum_host: 'yum.puppetlabs.com'
-yum_repo_path: '/opt/repository/yum/'
 build_gem: FALSE
 build_dmg: FALSE
 build_ips: FALSE
 build_pe:  FALSE
 apt_host: 'apt.puppetlabs.com'
 apt_repo_url: 'http://apt.puppetlabs.com'
-apt_repo_path: '/opt/repository/incoming'
 tar_host: 'downloads.puppetlabs.com'


### PR DESCRIPTION
Razor isn't deploying to a special path for apt or yum repos so let the
defaults from the team build data set the value.