### PR TITLE
(RAZOR-733) Remove management ports.

### DIFF
--- a/standalone.xml
+++ b/standalone.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?> 
+<?xml version='1.0' encoding='UTF-8'?>
 <server xmlns='urn:jboss:domain:1.4'>
     <extensions>
         <extension module='org.jboss.as.clustering.infinispan'/>
@@ -50,14 +50,6 @@
                 </authorization>
             </security-realm>
         </security-realms>
-        <management-interfaces>
-            <native-interface>
-                <socket-binding native='management-native'/>
-            </native-interface>
-            <http-interface console-enabled='false'>
-                <socket-binding http='management-http'/>
-            </http-interface>
-        </management-interfaces>
     </management>
     <profile>
         <subsystem xmlns='urn:jboss:domain:logging:1.2'>
@@ -144,7 +136,9 @@
         <subsystem xmlns='urn:jboss:domain:jmx:1.2'>
             <expose-resolved-model/>
             <expose-expression-model/>
-            <remoting-connector/>
+            <!-- use-management-endpoint=false added as part of the removal
+                 of uneeded management ports -->
+            <remoting-connector use-management-endpoint='false'/>
         </subsystem>
         <subsystem xmlns='urn:jboss:domain:messaging:1.3'>
             <hornetq-server>
@@ -325,15 +319,12 @@
         <interface name='unsecure'>
             <!--
               ~  Used for IIOP sockets in the standard configuration.
-              ~                  To secure JacORB you need to setup SSL 
+              ~                  To secure JacORB you need to setup SSL
               -->
             <inet-address value='${jboss.bind.address.unsecure:127.0.0.1}'/>
         </interface>
     </interfaces>
     <socket-binding-group name='standard-sockets' default-interface='public' port-offset='${jboss.socket.binding.port-offset:0}'>
-        <socket-binding name='management-native' interface='management' port='${jboss.management.native.port:9999}'/>
-        <socket-binding name='management-http' interface='management' port='${jboss.management.http.port:9990}'/>
-        <socket-binding name='management-https' interface='management' port='${jboss.management.https.port:9443}'/>
         <socket-binding name='ajp' port='8009'/>
         <socket-binding name='http' port='${http.port:8080}'/>
         <socket-binding name='https' port='8443'/>


### PR DESCRIPTION
Prior to this PR, torquebox was listening on 3 ports: 9999, 9990, and 9443.

## Acceptance Criteria
* run `netstat -tlnp` on the razor server host with the razor server service running
* Observe that ports 9999, 9990, and 9443 (management interface ports) are not listening

### Note, I also tailed the server log:
tail -f /var/log/razor-server/server.log

To verify there were no errors, as prior to adding 
```
            <remoting-connector use-management-endpoint='false'/>
```

*Service errors were being logged around dependencies.*

```
JBAS014775:    New missing/unsatisfied dependencies:
      service jboss.binding.management-http (missing) dependents: [service jboss.serverManagement.controller.management.http]
      service jboss.binding.management-native (missing) dependents: [service jboss.remoting.server.management]

11:12:14,145 ERROR [org.jboss.as] (Controller Boot Thread) JBAS015875: JBoss AS 7.2.x.slim.incremental.16 "Janus" started (with errors) in 8521ms - Started 147 of 223 services (2 services failed or missing dependencies, 73 services are passive or on-demand)
```